### PR TITLE
Remove build directory after the build

### DIFF
--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -88,6 +88,8 @@ ${kci_core}/build.py \
 """)
         }
     }
+
+    sh(script: """rm -rf ${kdir}""")
 }
 
 node("docker-builder") {


### PR DESCRIPTION
On builders that have multiple workspaces (for example staging builders with mattface/gtucker/media-subsystem) the disk space of a finished build will be left until the next time the job runs, which could be never. Sometimes that's up to 7GB for a linux source checkout and a completed build with lots of modules. 

As we're running the workspaces in tmpfs, leaving build trees around is wasteful, so clean them up at the end of each build.