### PR TITLE
Create a manifest file in JSON with the build details for the images

### DIFF
--- a/jenkins/debian/debos/rootfs.yaml
+++ b/jenkins/debian/debos/rootfs.yaml
@@ -32,6 +32,15 @@ actions:
     script: {{ $script }}
 
   - action: run
+    description: Create manifest file
+    chroot: false
+    script: scripts/create_manifest.sh
+
+  - action: run
+    chroot: false
+    command: cp ${ROOTDIR}/build_info.json ${ARTIFACTDIR}/{{ $basename -}}/build_info.json
+
+  - action: run
     description: Install extra packages
     chroot: true
     command: apt-get update && apt-get -y install --no-install-recommends {{ $extra_packages }}

--- a/jenkins/debian/debos/scripts/create_manifest.sh
+++ b/jenkins/debian/debos/scripts/create_manifest.sh
@@ -11,5 +11,7 @@ echo '{' >> $MANIFEST
 echo '  "date":' \"`date -u`\" ',' >> $MANIFEST
 echo '  "distro": "debian",' >> $MANIFEST
 echo '  "distro_version":' \"`cat /scratch/root/etc/debian_version`\" ',' >> $MANIFEST
-cat $BUILDFILE >> $MANIFEST
+if [ -f $BUILDFILE ]; then
+  cat $BUILDFILE >> $MANIFEST
+fi
 echo '}' >> $MANIFEST

--- a/jenkins/debian/debos/scripts/create_manifest.sh
+++ b/jenkins/debian/debos/scripts/create_manifest.sh
@@ -9,6 +9,7 @@ BUILDFILE="/scratch/root/build_info.txt"
 
 echo '{' >> $MANIFEST
 echo '  "date":' \"`date -u`\" ',' >> $MANIFEST
-echo '  "debian_release":' \"`cat /scratch/root/etc/debian_version`\" ',' >> $MANIFEST
+echo '  "distro": "debian",' >> $MANIFEST
+echo '  "distro_version":' \"`cat /scratch/root/etc/debian_version`\" ',' >> $MANIFEST
 cat $BUILDFILE >> $MANIFEST
 echo '}' >> $MANIFEST

--- a/jenkins/debian/debos/scripts/create_manifest.sh
+++ b/jenkins/debian/debos/scripts/create_manifest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Create a manifest in JSON with the build data
+
+MANIFEST="/scratch/root/build_info.json"
+BUILDFILE="/scratch/root/build_info.txt"
+
+echo '{' >> $MANIFEST
+echo '  "date":' \"`date -u`\" ',' >> $MANIFEST
+echo '  "debian_release":' \"`cat /scratch/root/etc/debian_version`\" ',' >> $MANIFEST
+cat $BUILDFILE >> $MANIFEST
+echo '}' >> $MANIFEST

--- a/jenkins/debian/debos/scripts/stretchtests.sh
+++ b/jenkins/debian/debos/scripts/stretchtests.sh
@@ -34,12 +34,16 @@ apt-get install --no-install-recommends -y  ${BUILD_DEPS}
 # Build tests                                                          #
 ########################################################################
 
+BUILDFILE=/build_info.txt
+echo '  "tests_suites": [' >> $BUILDFILE
 
 # Build libdrm
 ########################################################################
 
 mkdir -p /tmp/tests/libdrm && cd /tmp/tests/libdrm
 git clone --depth=1 git://anongit.freedesktop.org/mesa/drm .
+
+echo '    {"name": "drm", "git_url": "git://anongit.freedesktop.org/mesa/drm", "git_commit": ' \"`git rev-parse HEAD`\" '},' >> $BUILDFILE
 
 autoreconf --force --verbose --install
 ./configure --enable-intel --prefix=/tmp/tests/igt/usr/
@@ -54,6 +58,9 @@ cp -a /tmp/tests/igt/usr/lib/lib*.so* /usr/lib/
 
 mkdir -p /tmp/tests/igt-gpu-tools && cd /tmp/tests/igt-gpu-tools
 git clone --depth=1 git://anongit.freedesktop.org/drm/igt-gpu-tools .
+
+echo '    {"name": "igt-gpu-tools", "git_url": "git://anongit.freedesktop.org/drm/igt-gpu-tools", "git_commit": ' \"`git rev-parse HEAD`\" '},' >> $BUILDFILE
+
 
 PKG_CONFIG_PATH=/tmp/tests/igt/usr/lib/pkgconfig sh autogen.sh
 make V=1
@@ -72,8 +79,10 @@ cp -a /tmp/tests/igt2/usr/bin/* /usr/bin/
 ########################################################################
 
 mkdir -p /tmp/tests/v4l2-compliance && cd /tmp/tests/v4l2-compliance
-
 git clone --depth=1 git://linuxtv.org/v4l-utils.git .
+
+echo '    {"name": "v4l2-compliance", "git_url": "git://linuxtv.org/v4l-utils.git", "git_commit": ' \"`git rev-parse HEAD`\" '}' >> $BUILDFILE
+
 
 sh bootstrap.sh
 ./configure --prefix=/tmp/tests/v4l2/usr/ --with-udevdir=/tmp/tests/v4l2/usr/lib/udev
@@ -85,6 +94,7 @@ strip /tmp/tests/v4l2/usr/bin/* /tmp/tests/v4l2/usr/lib/*.so* /tmp/tests/v4l2/us
 rm -rf  /tmp/tests/v4l2/usr/include /tmp/tests/v4l2/usr/share /tmp/tests/v4l2/usr/lib/udev /tmp/tests/v4l2/usr/lib/pkgconfig/
 cp -a /tmp/tests/v4l2/usr/* /usr/
 
+echo '  ]' >> $BUILDFILE
 
 ########################################################################
 # Cleanup: remove files and packages we don't want in the images       #

--- a/src/org/kernelci/debian/RootFS.groovy
+++ b/src/org/kernelci/debian/RootFS.groovy
@@ -92,6 +92,7 @@ def makeImageStep(String pipeline_version, String arch, String debianRelease, St
                 archiveArtifacts artifacts: "${pipeline_version}/${arch}/full.rootfs.tar.xz", fingerprint: true
                 archiveArtifacts artifacts: "${pipeline_version}/${arch}/full.rootfs.cpio.gz", fingerprint: true
                 archiveArtifacts artifacts: "${pipeline_version}/${arch}/rootfs.ext4.xz", fingerprint: true
+                archiveArtifacts artifacts: "${pipeline_version}/${arch}/build_info.json", fingerprint: true
                 }
 
                 stage("Upload images for ${arch}") {


### PR DESCRIPTION
This is a re-implementation of #8 but with the output file in JSON format.
For `streetchtest.jpl` the file would be like this:
```
{
  "date": "Thu Sep 27 16:15:44 UTC 2018" ,
  "debian_release": "9.5" ,
  "tests_suites": [
    {"name": "drm", "git_url": "git://anongit.freedesktop.org/mesa/drm", "git_commit":  "4ec31fc31a4be909c8204164c844b4a18f098af7" },
    {"name": "igt-gpu-tools", "git_url": "git://anongit.freedesktop.org/drm/igt-gpu-tools", "git_commit":  "de5973d410bfba0bbf04c9e7dd9e898587fc361b" },
    {"name": "v4l2-compliance", "git_url": "git://linuxtv.org/v4l-utils.git", "git_commit":  "3874aa8eb1ff0c2e103d024ba5af915b1b26f098" }
  ]
}
```

For `streetch.jpl` :
```
{
  "date": "Thu Sep 27 16:15:44 UTC 2018" ,
  "debian_release": "9.5" ,
}
```

If eventually we want to add a lot of more date and make this files more complex, we'll have to reconsider making a more robust implementation.