### PR TITLE
Remove generic_defconfig from MIPS arch

### DIFF
--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -67,6 +67,9 @@ def addDefconfigs(configs, kdir, arch) {
             for (String config: found.tokenize(' \n'))
                 configs.add(config)
         }
+        if (arch == "mips") {
+            configs.remove("generic_defconfig")
+        }
     } else {
         echo("WARNING: No configs directory: ${configs_dir}")
     }


### PR DESCRIPTION
generic_defconfig is not designed to be built, so remove it from the automatically generated configs list