### PR TITLE
Add all_abi config frag if it exists in the tree

### DIFF
--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -122,7 +122,7 @@ def addExtraConfigs(configs, kdir, arch) {
         addExtraIfExists(extra, kdir, "arch/x86/configs/kvm_guest.config")
     }
 
-    for (String frag: ["debug", "kselftest"])
+    for (String frag: ["debug", "kselftest", "all_abi"])
         addExtraIfExists(extra, kdir, "kernel/configs/${frag}.config")
 
     if (params.TREE_NAME == "lsk" || params.TREE_NAME == "anders") {


### PR DESCRIPTION
Anders is working to add an all_abi config fragment to the tree, if this file exists we should try to build it.