### PR TITLE
Add retry logic to the docker pull

### DIFF
--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -124,8 +124,8 @@ node("docker && builder") {
             )
         }
     }
-
-    docker.image(docker_image).pull()
+    def j = new Job()
+    j.dockerPullWithRetry(docker_image)
     docker.image(docker_image).inside {
         stage("Build") {
             timeout(time: 180, unit: 'MINUTES') {

--- a/src/org/kernelci/util/Job.groovy
+++ b/src/org/kernelci/util/Job.groovy
@@ -33,3 +33,22 @@ def addBoolParams(params, bool_params) {
             [$class: "BooleanParameterValue", name: p.key, value: p.value])
     }
 }
+
+def dockerPullWithRetry(image, retries=10, sleep_time=1) {
+  def pulled = false
+  while (!pulled) {
+      try {
+          docker.image(image).pull()
+          pulled = true
+      }
+      catch (Exception e) {
+          if (!retries) {
+              throw e
+          }
+          echo("""Docker pull failed, retry count ${retries}: ${e.toString()}""")
+          sleep sleep_time
+          retries -= 1
+          sleep_time = sleep_time * 2
+      }
+  }
+}


### PR DESCRIPTION
Sometimes the docker pull command will timeout, presumably due to
dockerhub being unreachable. Catch this error, and retry the pull with
an increasing timeout.