### PR TITLE
jenkins/debian/debos/rootfs: mkdir <outputdir>

### DIFF
--- a/jenkins/debian/debos/rootfs.yaml
+++ b/jenkins/debian/debos/rootfs.yaml
@@ -39,7 +39,7 @@ actions:
 
   - action: run
     chroot: false
-    command: cp ${ROOTDIR}/build_info.json ${ARTIFACTDIR}/{{ $basename -}}/build_info.json
+    command: mkdir -p ${ARTIFACTDIR}/{{ $basename -}} ; cp ${ROOTDIR}/build_info.json ${ARTIFACTDIR}/{{ $basename -}}/build_info.json
 
   - action: run
     description: Install extra packages


### PR DESCRIPTION
When passing a output dir via -t basename:"output" and the directory
doesn't exists then debos finish with an error.
Rework so that the output directory gets created.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>