### PR TITLE
Ssuite testrootfs

### DIFF
--- a/jenkins/debian/debos/scripts/stretchssuite.sh
+++ b/jenkins/debian/debos/scripts/stretchssuite.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Important: This script is run under QEMU
+
+set -e
+
+# Build-depends needed to build the test suites, they'll be removed later
+BUILD_DEPS="
+            git \
+"
+
+apt-get install --no-install-recommends -y  ${BUILD_DEPS}
+
+BUILDFILE=/build_info.txt
+echo '  "tests_suites": [' >> $BUILDFILE
+
+# Build and install ssuite
+########################################################################
+
+TESTDIR=ssuite
+mkdir -p /tmp/tests/${TESTDIR} && cd /tmp/tests/${TESTDIR}
+
+TEST_REPO=git://github.com/Algodev-github/S.git
+
+git clone --depth=1 ${TEST_REPO} .
+
+echo '    {"name": "${TESTDIR}", "git_url": "${TEST_REPO}", "git_commit": ' \"`git rev-parse HEAD`\" '}' >> $BUILDFILE
+
+
+# Copy files in the image
+mkdir /opt/ssuite
+cp -Rd --preserve=mode,timestamps /tmp/tests/${TESTDIR}/* /opt/ssuite
+
+echo '  ]' >> $BUILDFILE
+
+########################################################################
+# Cleanup: remove files and packages we don't want in the images       #
+########################################################################
+cd /tmp
+rm -rf /tmp/tests
+
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get autoremove --purge -y
+apt-get clean
+
+# re-add some stuff that is removed by accident
+apt-get install -y initramfs-tools
+

--- a/jenkins/stretchssuite.jpl
+++ b/jenkins/stretchssuite.jpl
@@ -1,0 +1,13 @@
+@Library('kernelci') _
+import org.kernelci.debian.RootFS
+
+def r = new RootFS()
+
+def config = ['name':"stretchssuite",
+              'arch_list':["amd64"],
+              'debian_release':"stretch",
+              'extra_packages':"bash bc coreutils gawk g++ gcc fio libaio1 \
+                                libaio-dev sysstat",
+              'script':"scripts/stretchssuite.sh"]
+
+r.buildImage(config)

--- a/templates/ssuite/generic-ipxe-tftp-nfs-ssuite-template.jinja2
+++ b/templates/ssuite/generic-ipxe-tftp-nfs-ssuite-template.jinja2
@@ -1,0 +1,23 @@
+{% extends 'base/kernel-ci-base-tftp-deploy.jinja2' %}
+{% block metadata %}
+{{ super() }}
+{% endblock %}
+{% block main %}
+{{ super() }}
+{% endblock %}
+{% block actions %}
+{%- block deploy %}
+{{ super () }}
+{%- endblock %}
+
+- boot:
+    timeout:
+      minutes: 5
+    method: ipxe
+    commands: nfs
+    prompts:
+      - '{{ rootfs_prompt }}'
+
+{% include 'ssuite/ssuite.jinja2' %}
+
+{% endblock %}

--- a/templates/ssuite/ssuite.jinja2
+++ b/templates/ssuite/ssuite.jinja2
@@ -1,0 +1,22 @@
+- test:
+    timeout:
+      minutes: 10
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: ssuite
+          description: "ssuite test plan"
+          os:
+          - debian
+          scope:
+          - functional
+        run:
+          steps:
+          - cd /opt/ssuite
+          - cd run_multiple_benchmarks
+          - sudo ./run_main_benchmarks.sh "throughput replayed-startup" "bfq mq-deadline" raw
+      lava-signal: kmsg
+      from: inline
+      name: ssuite
+      path: inline/ssuite.yaml


### PR DESCRIPTION

This suite evaluates:
- responsiveness, by measuring start-up times of real applications
  under real background workloads
- latency for soft real-time applications, by measuring playback
  quality (drop rate) of video and audio under real background
  workloads
- speed of code-development tasks (make, git checkout, git merge, git
  grep) under real background workloads, plus responsiveness while one
  of these dev tasks is executed
- minimum per-client bandwidth guaranteed to a set of clients doing
  any possible type of I/O
- maximum per-client latency guaranteed to a set of clients doing any
  possible type of I/O
- throughput with processes doing filesystem or raw I/O in parallel
  (figure of merit measured by many other suites too)
- throughput with processes doing interleaved I/O, which mimics the
  typical I/O pattern of applications like qemu