### PR TITLE
build.py: add publish_path only if publishing

### DIFF
--- a/build.py
+++ b/build.py
@@ -519,9 +519,10 @@ if install:
             print "ERROR: TREE_NAME not set, aborting publish step"
             publish = False
 
-    publish_path = os.path.join(
-        job, git_branch, git_describe, arch, defconfig_full)
-    bmeta['file_server_resource'] = publish_path
+    if publish:
+        publish_path = os.path.join(
+            job, git_branch, git_describe, arch, defconfig_full)
+        bmeta['file_server_resource'] = publish_path
 
     # Create JSON format build metadata
     with open(os.path.join(install_path, 'build.json'), 'w') as json_file:


### PR DESCRIPTION
Need to check if publish=true before setting publish_path,
otherwise some undefined variables are used (e.g. job=None)

Signed-off-by: Kevin Hilman <khilman@baylibre.com>