### PR TITLE
clang-8/Dockerfile: remove gcc for hermetic build

### DIFF
--- a/jenkins/dockerfiles/clang-8/Dockerfile
+++ b/jenkins/dockerfiles/clang-8/Dockerfile
@@ -7,4 +7,5 @@ RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
 RUN apt-add-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain main'
 RUN apt-get update && apt-get install --no-install-recommends -y \
     clang-8 clang
+RUN apt-get autoremove -y gcc
 


### PR DESCRIPTION
Fixes #56
Suggested-by: @nathanchance

cc @gctucker @khilman