### PR TITLE
build.py: ARC: build/copy uImage.gz

### DIFF
--- a/build.py
+++ b/build.py
@@ -350,6 +350,8 @@ extra_configs(dot_config, kbuild_output)
 #
 if len(args) >= 1:
     build_target = args[0]
+elif arch == "arc":
+    build_target = "uImage.gz"
 result = do_make(build_target, log=True)
 
 # Build modules
@@ -400,6 +402,8 @@ if install:
         patterns = ['Image']
     elif arch == 'mips':
         patterns = ['vmlinux.bin.z', 'vmlinux.ecoff']
+    elif arch == "arc":
+        patterns = ['uImage.gz']
     else:
         patterns = ['bzImage']
 


### PR DESCRIPTION
For ARCH=arc builds, explicitly request building uImage.gz target, and
also copy that image to the install dir.

Without this, no kernel images are ever installed for arc.

yeSigned-off-by: Kevin Hilman <khilman@baylibre.com>