### PR TITLE
Add build-environment and file_server_resource to the metadata

### DIFF
--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -71,7 +71,7 @@ import org.kernelci.util.Job
 def buildConfig(config, kdir, kci_core) {
     def defconfig = sh(script: "echo ${config} | sed 's/\\+/ \\-c /g'",
                        returnStdout: true)
-    def opt = "-i"
+    def opt = "-i -E ${params.CC}-${params.CC_VERSION}"
 
     if (params.PUBLISH) {
         opt += " -e"

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -173,6 +173,8 @@ def get_job_params(config, test_config, defconfig, opts, build, plan):
         'context': device_type.context,
         'rootfs_prompt': rootfs.prompt,
         'plan_name': test_plan.name,
+        'file_server_resource': file_server_resource,
+        'build_environment': build.get('build_environment'),
     }
 
     job_params.update(test_plan.params)
@@ -224,10 +226,7 @@ def get_jobs_from_builds(config, builds, tests):
             continue
 
         defconfig = build['defconfig_full']
-
-        print("Working on build {}".format(' '.join(
-            [config.get('tree'), config.get('branch'), config.get('describe'),
-             arch, defconfig])))
+        print("Working on build: {}".format(build.get('file_server_resource')))
 
         for plan in config.get('plans'):
             opts = {

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -27,6 +27,8 @@ metadata:
   job.initrd_url: {{ initrd_url }}
   job.nfsrootfs_url: {{ nfsrootfs_url }}
   job.dtb_url: {{ dtb_url }}
+  job.file_server_resource: {{ file_server_resource }}
+  job.build_environment: {{ build_environment }}
 {%- endblock %}
 {% block main %}
 device_type: {{ device_type }}


### PR DESCRIPTION
Pass build-environment and file_server_resource to the LAVA job
metadata, so that they can used by the backend instead of creating a
bespoke file path.