### PR TITLE
jenkins/dockerfiles: clang need arch binutils

### DIFF
--- a/jenkins/dockerfiles/clang-8/Dockerfile
+++ b/jenkins/dockerfiles/clang-8/Dockerfile
@@ -8,3 +8,5 @@ RUN apt-add-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain main'
 RUN apt-get update && apt-get install --no-install-recommends -y \
     clang-8 clang
 
+# clang kernel builds still use arch-specific GNU as/ld
+RUN apt-get -y install binutils-aarch64-linux-gnu


### PR DESCRIPTION
Signed-off-by: Kevin Hilman <khilman@baylibre.com>