### PR TITLE
WIP: send data to experimental ES

### DIFF
--- a/build.py
+++ b/build.py
@@ -35,7 +35,7 @@
 import os
 import sys
 import subprocess
-import getopt
+import argparse
 import tempfile
 import fnmatch
 import shutil
@@ -77,8 +77,6 @@ build_target = None
 build_log = None
 build_log_f = None
 
-def usage():
-    print "Usage:", sys.argv[0], "[options] [make target]"
 
 def do_post_retry(url=None, data=None, headers=None, files=None):
     retry = True
@@ -154,6 +152,7 @@ job = None
 boot_cmd = None
 use_git = False
 use_environment = False
+notifications = []
 
 # temp frag file: used to collect all kconfig fragments
 kconfig_tmpfile_fd, kconfig_tmpfile = tempfile.mkstemp(prefix='kconfig-')
@@ -167,68 +166,103 @@ if os.environ.has_key('ARCH'):
 else:
     os.environ['ARCH'] = arch
 
-try:
-    opts, args = getopt.getopt(sys.argv[1:], "b:c:ip:sgeJ:E:j:")
+# Parse command line options
+parser = argparse.ArgumentParser()
+parser.add_argument("target", nargs="?",
+                    help="target image name")
+parser.add_argument("-b", "--boot-cmd",
+                    help="boot command")
+parser.add_argument("-c", "--defconfig",
+                    help="kernel configuration file name")
+parser.add_argument("-i", "--install", action='store_true',
+                    help="tell whether or not to install files")
+parser.add_argument("-p", "--parse-config", action='store_true',
+                    help="parse configurations from ~/.build.cfg")
+parser.add_argument("-s", "--silent-mode", action='store_true',
+                    help="silent mode")
+parser.add_argument("-g", "--git-build-info", dest="use_git", action='store_true',
+                    help="get build information from git")
+parser.add_argument("-e", "--environment-overwrite", dest="use_environment", action='store_true',
+                    help="read build variables from environment")
+parser.add_argument("-J", "--jason-save", dest='json_output_file',
+                    help="write build to local json file instead of publishing it")
+parser.add_argument("-E", "--build-environment",
+                    help="specify environment for this build")
+parser.add_argument("-j", "--jobs", dest="make_threads", type=int,
+                    help="number of parallel threads to run make")
+parser.add_argument("-n", "--notifications", nargs='+', metavar='url[:token]',
+                    help="when builds are done, send results file as a POST notification to given url(s). "
+                         "Ex: -n 'https://myhook.com/build[:token]' 'https://other.com[:token]'")
 
-except getopt.GetoptError as err:
-    print str(err) # will print something like "option -a not recognized"
-    sys.exit(2)
-for o, a in opts:
-    if o == "-b":
-        boot_cmd = a
-        install = True
-    if o == '-c':
-        defs = a.split('+')
-        for a in defs:
-            if os.path.exists("arch/%s/configs/%s" % (arch, a)):
-                defconfig = a
-            elif a == "defconfig" or a == "tinyconfig" or re.match("all(\w*)config", a):
-                defconfig = a
-            elif os.path.exists(a):
-                # Append fragment contents to temp frag file
-                frag = open(a)
-                os.write(kconfig_tmpfile_fd, "\n# fragment from: %s\n" %a)
-                for line in frag:
-                    os.write(kconfig_tmpfile_fd, line)
-                frag.close()
-                frag_names.append(os.path.basename(os.path.splitext(a)[0]))
-            elif a.startswith("CONFIG_"):
-                # add to temp frag file
-                os.write(kconfig_tmpfile_fd, a + "\n")
-                os.fsync(kconfig_tmpfile_fd)
-                frag_names.append(a)
-            else:
-                print "ERROR: kconfig file/fragment (%s) doesn't exist" %a
-                sys.exit(1)
+args = parser.parse_args()
+if args.boot_cmd:
+    boot_cmd = args.boot_cmd
+    install = True
+if args.defconfig:
+    defs = args.defconfig.split('+')
+    for a in defs:
+        if os.path.exists("arch/%s/configs/%s" % (arch, a)):
+            defconfig = a
+        elif a == "defconfig" or a == "tinyconfig" or re.match("all(\w*)config", a):
+            defconfig = a
+        elif os.path.exists(a):
+            # Append fragment contents to temp frag file
+            frag = open(a)
+            os.write(kconfig_tmpfile_fd, "\n# fragment from: %s\n" %a)
+            for line in frag:
+                os.write(kconfig_tmpfile_fd, line)
+            frag.close()
+            frag_names.append(os.path.basename(os.path.splitext(a)[0]))
+        elif a.startswith("CONFIG_"):
+            # add to temp frag file
+            os.write(kconfig_tmpfile_fd, a + "\n")
+            os.fsync(kconfig_tmpfile_fd)
+            frag_names.append(a)
+        else:
+            print "ERROR: kconfig file/fragment (%s) doesn't exist" %a
+            sys.exit(1)
 
-    if o == '-i':
-        install = True
-    if o == '-p':
-        config = ConfigParser.ConfigParser()
-        try:
-            config.read(os.path.expanduser('~/.buildpy.cfg'))
-            api = config.get(a, 'api')
-            token = config.get(a, 'token')
-            publish = True
-        except:
-            print "ERROR: unable to load configuration file"
-    if o == '-s':
-        silent = not silent
-    if o == '-g':
-        print("Getting build info from git")
-        use_git = True
-    if o == '-e':
-        print "Reading build variables from environment"
+if args.install:
+    install = True
+if args.parse_config:
+    config = ConfigParser.ConfigParser()
+    try:
+        config.read(os.path.expanduser('~/.buildpy.cfg'))
+        api = config.get('api')
+        token = config.get('token')
         publish = True
-        use_environment = True
-    if o == '-J':
-        print("Not posting build data but saving to local JSON instead")
-        build_data_json = a
-    if o == '-j':
-        make_threads = int(a)
-        print("Parallel builds: {}".format(make_threads))
-    if o == '-E':
-        build_environment = a
+    except:
+        print "ERROR: unable to load configuration file"
+if args.silent_mode:
+    silent = not silent
+if args.use_git:
+    print("Getting build info from git")
+    use_git = True
+if args.use_environment:
+    print "Reading build variables from environment"
+    publish = True
+    use_environment = True
+if args.build_environment:
+    print "Reading build variables from environment"
+    build_environment = args.build_environment
+if args.json_output_file:
+    print("Not posting build data but saving to local JSON instead")
+    build_data_json = args.json_output_file
+if args.make_threads:
+    make_threads = int(args.make_threads)
+    print("Parallel builds: {}".format(make_threads))
+if args.notifications:
+    for n in args.notifications:
+        params = n.split(':')
+        params_len = len(params)
+        if params_len > 3 or params_len <= 1:
+            print('Discarding malformed notification url "%s"' % n)
+            continue
+
+        # rebuild url
+        _url = '%s:%s' % (params[0], params[1])
+        _token = None if params_len == 2 else params[2]
+        notifications.append({'url': _url, 'token': _token})
 
 # Default umask for file creation
 os.umask(022)
@@ -366,8 +400,8 @@ extra_configs(dot_config, kbuild_output)
 #
 # Build kernel
 #
-if len(args) >= 1:
-    build_target = args[0]
+if args.target:
+    build_target = args.target
 elif arch == "arc":
     build_target = "uImage.gz"
 elif arch == "mips":
@@ -555,6 +589,19 @@ if install:
     # Create JSON format build metadata
     with open(os.path.join(install_path, 'build.json'), 'w') as json_file:
         json.dump(bmeta, json_file, indent=4, sort_keys=True)
+
+    # Send notifications
+    if len(notifications):
+        build_content = open(os.path.join(install_path, 'build.json'), 'r').read()
+        for n in notifications:
+            print("Notifying '%s'" % n['url'])
+            _headers = {'Content-Type': 'application/json'}
+            if n['token']:
+                _headers['Authorization'] = n['token']
+
+            _, status_code = do_post_retry(url=n['url'], data=build_content, headers=_headers)
+            if divmod(status_code, 100)[0] != 2:
+                print("Failed to send build notification to '%s'" % n['url'])
 
     if publish and job:
         artifacts = []

--- a/callbacks.yaml.example
+++ b/callbacks.yaml.example
@@ -1,0 +1,15 @@
+# Callback A example
+#- type: custom
+#  token: actual-token-or-token-name
+#  url: https://url.to.your.listener/with/path/or/not
+#  dataset: minimal|logs|results|all
+#  method: POST|GET
+#  content-type: json|urlencoded
+
+# Callback B example with template fields
+#- type: custom
+#  token: actual-token-or-token-name
+#  url: https://url.to.your.listener?id={ID}&status={STATUS}&status_string={STATUS_STRING}
+#  dataset: minimal|logs|results|all
+#  method: POST|GET
+#  content-type: json|urlencoded

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -39,21 +39,29 @@ context:
 {% endfor %}
 {% endif %}
 
-{%- if callback %}
+{%- if callbacks %}
 notify:
   criteria:
     status: finished
-  callback:
-{%- if callback_type == 'custom' %}
-    url: {{ callback_url }}
+  callbacks:
+{%- for callback in callbacks %}
+{%- if callback['type'] == 'custom' %}
+    - url: {{ callback['url'] }}
+      imethod: {{ callback['method'] }}
+      dataset: {{ callback['dataset'] }}
+      {%- if callback['token'] %}
+      token: {{ callback['token'] }}
+      {%- endif %}
+      content-type: {{ callback['content-type'] }}
 {%- else %}
-    url: {{ callback_url }}/callback/{{ callback_name }}?lab_name={{ lab_name }}&status={STATUS}&status_string={STATUS_STRING}
+    - url: {{ callback['url'] }}/callback/{{ callback['name'] }}?lab_name={{ lab_name }}&status={STATUS}&status_string={STATUS_STRING}
+      method: POST
+      dataset: {{ callback['dataset'] }}
+      token: {{ callback['token'] }}
+      content-type: json
 {%- endif %}
-    method: POST
-    dataset: {{ callback_dataset }}
-    token: {{ callback }}
-    content-type: json
-{% endif %}
+{%- endfor %}
+{%- endif %}
 
 job_name: {{ name }}
 timeouts:


### PR DESCRIPTION
On last Monday call (10/12/18) Milosz suggested a patch in kernelci so that job results from lava would also be sent to our experimental ElasticSearch instance. 

This patch does two things:
1. Sends a copy of `build.json` to our server
2. Changed lava test job definition to add an extra callback when `callback_type != 'custom'` 
2.1. Apparently only LAVA V2 labs after 2018.5 support to multiple callbacks and from https://github.com/kernelci/kernelci-core-staging/blob/master/labs.ini, I came up with this list:
- lab-baylibre: 2018.11-1~bpo9+1
- lab-baylibre-dev: 2018.11-1~bpo9+1
- lab-baylibre-seattle: offline
- lab-baylibre-seattle-dev: offline
- lab-broonie: offline
- lab-broonie-dev: offline
- lab-collabora: 2018.11-1~bpo9+1.1debian9.1
- lab-collabora-dev: 2018.11-1~bpo9+1.1debian9.1
- lab-embeddedbits: offline
- lab-embeddedbits-dev: offline
- lab-pengutronix: offline
- lab-pengutronix-dev: offline
- lab-free-electrons: offline
- lab-free-electrons-dev: offline
- lab-jsmoeller: offline
- lab-jsmoeller-dev: offline
- lab-mhart: 2018.5.post1-1+stretch
- lab-mhart-dev: 2018.5.post1-1+stretch
- lab-linaro-lkft: 2018.11+stretch
- lab-linaro-lkft-dev: 2018.11+stretch
- _lab-theobroma-systems: 2018.2-1+stretch_
- _lab-theobroma-systems-dev: 2018.2-1+stretch_

Since kernelci-core-staging uses matt's, collabora's and baylibre's lab, we're safe adding the multiple callbacks block in the test job definition