### PR TITLE
enable building with clang

### DIFF
--- a/build.py
+++ b/build.py
@@ -294,7 +294,7 @@ if use_environment:
     git_branch = os.environ.get('BRANCH', git_branch)
     git_describe = os.environ.get('GIT_DESCRIBE', git_describe)
     git_describe_v = os.environ.get('GIT_DESCRIBE_VERBOSE', git_describe_v)
-    build_environment = os.environ.get('COMPILER', build_environment)
+    build_environment = os.environ.get('CC', build_environment)
 
 start_time = time.time()
 

--- a/build.py
+++ b/build.py
@@ -102,13 +102,17 @@ def do_make(target=None, log=False):
     if silent:
         make_args += "-s "
     make_args += "ARCH=%s " %arch
+    if (cc != "gcc") and not ccache:
+        make_args += "CC=%s " % cc
+    if cc:
+        make_args += "HOSTCC=%s " % cc
     if cross_compile:
         make_args += "CROSS_COMPILE=%s " %cross_compile
     if ccache:
         prefix = ''
-        if cross_compile:
+        if cross_compile and cc == "gcc":
             prefix = cross_compile
-        make_args += 'CC="ccache %sgcc" ' %prefix
+        make_args += 'CC="ccache %s%s" ' %(prefix, cc)
     if kbuild_output:
         make_args += "O=%s " %kbuild_output
     if target:
@@ -236,10 +240,19 @@ else:
     if cross_compile:
         os.environ['CROSS_COMPILE'] = cross_compile
 
+# CC
+cc = os.environ.get("CC", "gcc")
+cc_cmd = "%s --version 2>&1" % cc
+if cross_compile and cc == "gcc":
+    cc_cmd = "%s%s --version 2>&1" %(cross_compile, cc)
+cc_version = subprocess.check_output(cc_cmd, shell=True).splitlines()[0]
+
 # KBUILD_OUTPUT
 kbuild_output = kbuild_output_prefix
 if arch:
     kbuild_output += "-%s" % arch
+    if cc != "gcc":
+        kbuild_output += "-%s" % cc
 if os.environ.has_key('KBUILD_OUTPUT'):
     kbuild_output = os.environ['KBUILD_OUTPUT']
 else:
@@ -259,7 +272,8 @@ if ccache and len(ccache):
         ccache_dir = os.environ['CCACHE_DIR']
     else:
         ccache_dir = os.path.join(os.getcwd(), '.ccache' + '-' + arch)
-        #ccache_dir = os.path.join(os.getcwd(), '.ccache')
+        if cc != "gcc":
+            ccache_dir += "-" + cc
         os.environ['CCACHE_DIR'] = ccache_dir
 else:
     ccache_dir = None
@@ -281,11 +295,6 @@ if use_environment:
     git_describe = os.environ.get('GIT_DESCRIBE', git_describe)
     git_describe_v = os.environ.get('GIT_DESCRIBE_VERBOSE', git_describe_v)
     build_environment = os.environ.get('COMPILER', build_environment)
-
-cc_cmd = "gcc -v 2>&1"
-if cross_compile:
-    cc_cmd = "%sgcc -v 2>&1" %cross_compile
-gcc_version = subprocess.check_output(cc_cmd, shell=True).splitlines()[-1]
 
 start_time = time.time()
 
@@ -472,7 +481,7 @@ if install:
 
     bmeta['arch'] = "%s" %arch
     bmeta["cross_compile"] = "%s" %cross_compile
-    bmeta["compiler_version"] = "%s" %gcc_version
+    bmeta["compiler_version"] = "%s" %cc_version
     bmeta["build_environment"] = "%s" % build_environment
     bmeta["git_url"] = "%s" %git_url
     bmeta["git_branch"] =  "%s" %git_branch

--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -40,8 +40,10 @@ GIT_DESCRIBE_VERBOSE
   Verbose output of 'git describe' at the revision of the snapshot
 COMMIT_ID
   Git commit SHA1 at the revision of the snapshot
-COMPILER (gcc-7)
-  Name and version number of the compiler
+CC (gcc)
+  Name the compiler
+CC_VERSION (7)
+  Version of the compiler
 PUBLISH (boolean)
   Publish build results via the KernelCI backend API
 EMAIL (boolean)
@@ -99,7 +101,7 @@ ${kci_core}/build.py \
 node("docker && builder") {
     def j = new Job()
     def docker_image = j.dockerImageName(
-        params.DOCKER_BASE, params.COMPILER, params.ARCH)
+        params.DOCKER_BASE, params.CC, params.CC_VERSION, params.ARCH)
 
     echo("""\
     Tree:      ${params.TREE_NAME}
@@ -109,7 +111,7 @@ node("docker && builder") {
     Describe:  ${params.GIT_DESCRIBE}
     Revision:  ${params.COMMIT_ID}
     Config:    ${params.DEFCONFIG}
-    Compiler:  ${params.COMPILER}
+    Compiler:  ${params.CC} ${params.CC_VERSION}
     Container: ${docker_image}""")
 
     def k = new Kernel()

--- a/jenkins/dockerfiles/clang-8/Dockerfile
+++ b/jenkins/dockerfiles/clang-8/Dockerfile
@@ -6,5 +6,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
 RUN apt-add-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain main'
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    clang-8 clang
+    binutils-aarch64-linux-gnu \
+    clang-8
 
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 500

--- a/jenkins/dockerfiles/clang-8/Dockerfile
+++ b/jenkins/dockerfiles/clang-8/Dockerfile
@@ -10,3 +10,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     clang-8
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 500
+
+RUN apt-get autoremove -y gcc

--- a/src/org/kernelci/util/Job.groovy
+++ b/src/org/kernelci/util/Job.groovy
@@ -34,7 +34,7 @@ def addBoolParams(params, bool_params) {
     }
 }
 
-def dockerImageName(base, compiler, kernel_arch) {
+def dockerImageName(base, cc, cc_version, kernel_arch) {
     def docker_arch
 
     if (arch == "riscv")
@@ -44,7 +44,7 @@ def dockerImageName(base, compiler, kernel_arch) {
     else
         docker_arch = arch
 
-    return "${base}${compiler}_${docker_arch}"
+    return "${base}${cc}-${cc_version}_${docker_arch}"
 }
 
 def dockerPullWithRetry(image_name, retries=10, sleep_time=1) {

--- a/src/org/kernelci/util/Job.groovy
+++ b/src/org/kernelci/util/Job.groovy
@@ -35,16 +35,22 @@ def addBoolParams(params, bool_params) {
 }
 
 def dockerImageName(base, cc, cc_version, kernel_arch) {
-    def docker_arch
+    def image_name = "${base}${cc}-${cc_version}"
 
-    if (arch == "riscv")
-        docker_arch = "riscv64"
-    else if ((arch == "i386") || (arch == "x86_64"))
-        docker_arch = "x86"
-    else
-        docker_arch = arch
+    if (cc == "gcc") {
+        def docker_arch
+       
+        if (kernel_arch == "riscv")
+       	    docker_arch = "riscv64"
+        else if ((kernel_arch == "i386") || (kernel_arch == "x86_64"))
+            docker_arch = "x86"
+        else
+            docker_arch = kernel_arch
 
-    return "${base}${cc}-${cc_version}_${docker_arch}"
+	image_name = "${image_name}_${docker_arch}"
+    }
+
+    return image_name;
 }
 
 def dockerPullWithRetry(image_name, retries=10, sleep_time=1) {


### PR DESCRIPTION
Add support to the build tools and docker images to support clang

Prerequisites to merge:
- new docker images are build/pushed to docker hub
- the jenkins jobs need updates for the new variables: COMPILER changed to CC, and CC_VERSION was added.