### PR TITLE
labs.ini: remove lab-baylibre-seattle

### DIFF
--- a/jenkins/lava-boot-v2.sh
+++ b/jenkins/lava-boot-v2.sh
@@ -32,9 +32,6 @@ elif [ ${LAB} = "lab-baylibre-dev" ]; then
   # for dev lab, also send results to BayLibre kernelCI development backend
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback kernelci-dev-baylibre-callback --callback-url http://kernelci.dev.baylibre.com:8081 --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans simple usb --token ${API_TOKEN} --priority low
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_BAYLIBRE_TOKEN} --lab ${LAB}
-elif [ ${LAB} = "lab-baylibre-seattle" ]; then
-  python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi kselftest --token ${API_TOKEN} --priority medium
-  python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_BAYLIBRE_SEATTLE_TOKEN} --lab ${LAB}
 elif [ ${LAB} = "lab-free-electrons" ] || [ ${LAB} = "lab-free-electrons-dev" ]; then
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN} --priority medium
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_FREE_ELECTRONS_TOKEN} --lab ${LAB}
@@ -44,9 +41,6 @@ elif [ ${LAB} = "lab-broonie" ]; then
 elif [ ${LAB} = "lab-embeddedbits" ]; then
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_EMBEDDEDBITS_TOKEN} --lab ${LAB}
-elif [ ${LAB} = "lab-jsmoeller" ]; then
-  python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
-  python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_JSMOELLER_TOKEN} --lab ${LAB}
 elif [ ${LAB} = "lab-pengutronix" ] || [ ${LAB} = "lab-pengutronix-dev" ]; then
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_PENGUTRONIX_TOKEN} --lab ${LAB}

--- a/labs.ini
+++ b/labs.ini
@@ -6,14 +6,6 @@ api: http://lava.baylibre.com:10080/RPC2/
 tree_blacklist: drm-tip
 api: http://lava.baylibre.com:10080/RPC2/
 
-[lab-baylibre-seattle]
-tree_blacklist: drm-tip
-api: http://lava.ished.com/RPC2/
-
-[lab-baylibre-seattle-dev]
-tree_blacklist: drm-tip
-api: http://lava.ished.com/RPC2/
-
 [lab-broonie]
 api: http://lava.sirena.org.uk/RPC2/
 
@@ -45,12 +37,6 @@ api: https://lab.free-electrons.com/RPC2/
 [lab-free-electrons-dev]
 tree_blacklist: linaro-android drm-tip
 api: https://lab.free-electrons.com/RPC2/
-
-[lab-jsmoeller]
-api: https://88.198.106.157/mylava/RPC2/
-
-[lab-jsmoeller-dev]
-api: https://88.198.106.157/mylava/RPC2/
 
 [lab-mhart]
 tree_blacklist: linaro-android drm-tip android


### PR DESCRIPTION
This lab doesn't exist anymore.  Instead, boards in seattle are
connected via a remote slave to the main lab-baylibre.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>