### PR TITLE
Use custom debos container

### DIFF
--- a/jenkins/debian/Dockerfile_debos
+++ b/jenkins/debian/Dockerfile_debos
@@ -1,4 +1,0 @@
-FROM docker-registry.collabora.com/debos:latest
-
-RUN apt-get update
-RUN apt-get install --no-install-recommends xz-utils

--- a/jenkins/dockerfiles/debos/Dockerfile
+++ b/jenkins/dockerfiles/debos/Dockerfile
@@ -1,0 +1,50 @@
+FROM debian:stretch-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Docker for Jenkins really needs procps otherwise the Jenkins side fails
+RUN apt-get update && apt-get install --no-install-recommends -y procps
+
+# Set HOME to a writable directory in case something wants to cache things
+# (e.g. obs)
+ENV HOME=/tmp
+ENV GOPATH=/usr/local/go
+ENV PATH=$PATH:/usr/local/go/bin
+
+# SSL / HTTPS support
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    apt-transport-https \
+    ca-certificates
+
+# Dependencies to build debos
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    golang-go \
+    git \
+    libostree-dev \
+    gcc \
+    libc6-dev
+
+# Build debos
+RUN go get github.com/go-debos/debos/cmd/debos && \
+    go install github.com/go-debos/debos/cmd/debos
+
+# Dependencies to run debos
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    debootstrap \
+    pkg-config \
+    busybox \
+    linux-image-amd64 \
+    qemu-system-x86 \
+    qemu-user-static \
+    systemd-container \
+    binfmt-support \
+    parted \
+    dosfstools \
+    e2fsprogs
+
+# Extra packages needed by kernelCI
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python \
+    python-requests \
+    xz-utils
+

--- a/src/org/kernelci/debian/RootFS.groovy
+++ b/src/org/kernelci/debian/RootFS.groovy
@@ -27,11 +27,6 @@ KCI_TOKEN_ID
 
 */
 
-
-/* TODO:
-- Harcoded paths at jenkins/debian/... for Dockerfile and debos file
-*/
-
 package org.kernelci.debian
 
 
@@ -91,7 +86,7 @@ def makeImageStep(String pipeline_version,
                 checkout scm
             }
 
-            docker.build("debian", "-f jenkins/debian/Dockerfile_debos --pull .").inside("--device=/dev/kvm ${getDockerArgs()}") {
+            docker.image('kernelci/debos').inside("--device=/dev/kvm ${getDockerArgs()}") {
                 stage("Build base image for ${arch}") {
                     sh """
                         mkdir -p ${pipeline_version}/${arch}


### PR DESCRIPTION
Stop using collabora's docker registry and switch to a kernelci owned image.
Before merging this, the new docker image must be build/pushed to kernelci's docker hub