### PR TITLE
build.py: MIPS: set build_target to all

### DIFF
--- a/build.py
+++ b/build.py
@@ -368,8 +368,10 @@ extra_configs(dot_config, kbuild_output)
 #
 if len(args) >= 1:
     build_target = args[0]
-elif arch == "arc" or arch == "mips":
+elif arch == "arc":
     build_target = "uImage.gz"
+elif arch == "mips":
+    build_target = "all"
 result = do_make(build_target, log=True)
 
 # Build modules


### PR DESCRIPTION
Most of MIPS defconfigs have the build target "uImage.gz", but not all.
To be sure that all defconfigs build, use the "all" target instead.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>