### PR TITLE
Update clang builder docker images

### DIFF
--- a/jenkins/dockerfiles/clang-8/Dockerfile
+++ b/jenkins/dockerfiles/clang-8/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     software-properties-common \
     gnupg2
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
-RUN apt-add-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain main'
+RUN apt-add-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain-8 main'
 RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-aarch64-linux-gnu \
     clang-8

--- a/jenkins/dockerfiles/clang-9/Dockerfile
+++ b/jenkins/dockerfiles/clang-9/Dockerfile
@@ -1,0 +1,14 @@
+FROM kernelci/build-base
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    software-properties-common \
+    gnupg2
+RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
+RUN apt-add-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain main'
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    binutils-aarch64-linux-gnu \
+    clang-9
+
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 500
+
+RUN apt-get autoremove -y gcc


### PR DESCRIPTION
Fix the clang-8 dockerfile as it was unbuildable (the apt repo didnt have a clang-8 package)

Add a clang-9 dockerfile for future use