### PR TITLE
build-configs.yaml: add Linus Walleij's gpio tree

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -58,6 +58,9 @@ trees:
   linaro-android:
     url: "https://android-git.linaro.org/git/kernel/linaro-android.git"
 
+  linusw:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/linusw/linux-gpio.git/"
+
   lsk:
     url: "https://git.linaro.org/kernel/linux-linaro-stable.git"
 
@@ -288,6 +291,10 @@ build_configs:
   linaro-android:
     tree: linaro-android
     branch: 'linaro-android-llct'
+
+  linusw:
+    tree: linusw
+    branch: ['devel', 'fixes', 'for-next']
 
   lsk_for-test:
     tree: lsk


### PR DESCRIPTION
Add Linus Walleij's gpio tree and three branches 'devel', 'fixes' and
'for-next'.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>