### PR TITLE
build-configs.yaml: splitup one entry per branch and tree

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -295,9 +295,17 @@ build_configs:
     tree: linaro-android
     branch: 'linaro-android-llct'
 
-  linusw:
+  linusw_devel:
     tree: linusw
-    branch: ['devel', 'fixes', 'for-next']
+    branch: 'devel'
+
+  linusw_fixes:
+    tree: linusw
+    branch: 'fixes'
+
+  linusw_for-next:
+    tree: linusw
+    branch: 'for-next'
 
   lsk_for-test:
     tree: lsk


### PR DESCRIPTION
The build config entry can only have one tree and one branch.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>