### PR TITLE
Add arm and arm64 builds of clang-8 to production

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -76,6 +76,9 @@ trees:
   next:
     url: 'git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'
 
+  next-clang:
+    url: 'git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'
+
   omap:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/tmlind/linux-omap.git"
 
@@ -384,6 +387,14 @@ build_configs:
   next:
     tree: next
     branch: 'master'
+
+  next_clang:
+    tree: next-clang
+    branch: 'master'
+    variants:
+      clang-8:
+        build_environment: clang-8
+        arch_list: ['arm', 'arm64']
 
   next_pending-fixes:
     tree: next

--- a/jenkins/kernel-arch-complete.sh
+++ b/jenkins/kernel-arch-complete.sh
@@ -197,6 +197,10 @@ if [[ BUILDS_FINISHED -eq 4 ]]; then
         echo "Sending results for media tree"
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "v4l2-compliance-vivid", "send_to": ["gtucker@collabora.com", "ezequiel@collabora.com"], "format": ["txt"], "delay": 5400}' ${API}/send
         curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "v4l2-compliance-uvc", "send_to": ["gtucker@collabora.com", "ezequiel@collabora.com"], "format": ["txt"], "delay": 5400}' ${API}/send
+    elif [ "$TREE_NAME" == "next-clang" ]; then
+        echo "Sending results to Linux Next (clang only)"
+        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "build_report": 1, "send_to": ["natechancellor@gmail.com", "broonie@kernel.org", "arnd.bergmann@linaro.org", "ndesaulniers@google.com", "kernel-build-reports@lists.linaro.org", "trong@google.com", "matthew.hart@linaro.org"], "format": ["txt"], "delay": 10}' ${API}/send
+        curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "boot_report": 1, "send_to": ["natechancellor@gmail.com", "broonie@kernel.org", "arnd.bergmann@linaro.org", "ndesaulniers@google.com", "kernel-build-reports@lists.linaro.org", "trong@google.com", "matthew.hart@linaro.org"], "format": ["txt"], "delay": 12600}' ${API}/send
     else
         # Private Mailing List
         echo "Sending results to private mailing list"


### PR DESCRIPTION
Use the production build and boot infrastructure to test clang-8 for
a subset of architectures (armv7 and arm64).

As arm64 is a little noisy, and armv7 will likely be extremely noisy,
use a limited recipient list to not annoy the linux-next list.
@broonie is that the expected behaviour? ^

As the arch-complete job can't currently deal with different email
recipients for different builds, use a different tree name until
such time as it can.

FYI, I've also moved a gce builder over to production ready for
this but can add more if needed.