### PR TITLE
Add arm64 clang-8 builds to linux-next

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -384,6 +384,14 @@ build_configs:
   next:
     tree: next
     branch: 'master'
+    variants:
+      clang-8:
+        build_environment: clang-8
+        arch_list: ['arm64']
+      gcc-7:
+        build_environment: gcc-7
+        arch_list: *default_arch_list
+
 
   next_pending-fixes:
     tree: next


### PR DESCRIPTION
Add arm64 clang builds to linux-next, keeping gcc-7 as well.

This will only add 1 currently known failing build which is allmodconfig.